### PR TITLE
Rendert DataObject-Collection-Marker passend zum Theme

### DIFF
--- a/lib/draw/BpmnRenderer.js
+++ b/lib/draw/BpmnRenderer.js
@@ -1902,7 +1902,8 @@ export default function BpmnRenderer(
     });
 
     /* collection path */ drawPath(parentGfx, pathData, {
-      strokeWidth: 2
+      strokeWidth: 2,
+      stroke: getStrokeColor(element, defaultStrokeColor)
     });
   }
 


### PR DESCRIPTION
## Beschreibung

DataObject-Collection-Marker haben beim Rendern nicht beachtet, in welchem Theme sich das Studio gerade befindet und wurden immer schwarz gezeichnet - im Dark Theme eher ungünstig.