### PR TITLE
(PCE-1306) Fixed Lane-Name Bearbeitung im Whitemode

### DIFF
--- a/assets/bpmn-js.css
+++ b/assets/bpmn-js.css
@@ -1,20 +1,20 @@
 .bjs-container {
   --bjs-font-family: Arial, sans-serif;
 
-  --color-grey-225-10-15: hsl(0, 100%, 50%);
-  --color-grey-225-10-35: hsl(0, 100%, 50%);
-  --color-grey-225-10-55: hsl(0, 100%, 50%);
-  --color-grey-225-10-75: hsl(0, 100%, 50%);
-  --color-grey-225-10-80: hsl(0, 100%, 50%);
-  --color-grey-225-10-85: hsl(0, 100%, 50%);
-  --color-grey-225-10-90: hsl(0, 100%, 50%);
-  --color-grey-225-10-95: hsl(0, 100%, 50%);
-  --color-grey-225-10-97: hsl(0, 100%, 50%);
+  --color-grey-225-10-15: hsl(225, 10%, 15%);
+  --color-grey-225-10-35: hsl(225, 10%, 35%);
+  --color-grey-225-10-55: hsl(225, 10%, 55%);
+  --color-grey-225-10-75: hsl(225, 10%, 75%);
+  --color-grey-225-10-80: hsl(225, 10%, 80%);
+  --color-grey-225-10-85: hsl(225, 10%, 85%);
+  --color-grey-225-10-90: hsl(225, 10%, 90%);
+  --color-grey-225-10-95: hsl(225, 10%, 95%);
+  --color-grey-225-10-97: hsl(225, 10%, 97%);
 
-  --color-blue-205-100-45: hsl(0, 100%, 50%);
-  --color-blue-205-100-45-opacity-30: hsl(0, 100%, 50%);
-  --color-blue-205-100-50: hsl(0, 100%, 50%);
-  --color-blue-205-100-95: hsl(0, 100%, 50%);
+  --color-blue-205-100-45: hsl(205, 100%, 45%);
+  --color-blue-205-100-45-opacity-30: hsla(205, 100%, 45%, 30%);
+  --color-blue-205-100-50: hsl(205, 100%, 50%);
+  --color-blue-205-100-95: hsl(205, 100%, 95%);
 
   --color-green-150-86-44: hsl(150, 86%, 44%);
 

--- a/assets/bpmn-js.css
+++ b/assets/bpmn-js.css
@@ -1,20 +1,20 @@
 .bjs-container {
   --bjs-font-family: Arial, sans-serif;
 
-  --color-grey-225-10-15: hsl(225, 10%, 15%);
-  --color-grey-225-10-35: hsl(225, 10%, 35%);
-  --color-grey-225-10-55: hsl(225, 10%, 55%);
-  --color-grey-225-10-75: hsl(225, 10%, 75%);
-  --color-grey-225-10-80: hsl(225, 10%, 80%);
-  --color-grey-225-10-85: hsl(225, 10%, 85%);
-  --color-grey-225-10-90: hsl(225, 10%, 90%);
-  --color-grey-225-10-95: hsl(225, 10%, 95%);
-  --color-grey-225-10-97: hsl(225, 10%, 97%);
+  --color-grey-225-10-15: hsl(0, 100%, 50%);
+  --color-grey-225-10-35: hsl(0, 100%, 50%);
+  --color-grey-225-10-55: hsl(0, 100%, 50%);
+  --color-grey-225-10-75: hsl(0, 100%, 50%);
+  --color-grey-225-10-80: hsl(0, 100%, 50%);
+  --color-grey-225-10-85: hsl(0, 100%, 50%);
+  --color-grey-225-10-90: hsl(0, 100%, 50%);
+  --color-grey-225-10-95: hsl(0, 100%, 50%);
+  --color-grey-225-10-97: hsl(0, 100%, 50%);
 
-  --color-blue-205-100-45: hsl(205, 100%, 45%);
-  --color-blue-205-100-45-opacity-30: hsla(205, 100%, 45%, 30%);
-  --color-blue-205-100-50: hsl(205, 100%, 50%);
-  --color-blue-205-100-95: hsl(205, 100%, 95%);
+  --color-blue-205-100-45: hsl(0, 100%, 50%);
+  --color-blue-205-100-45-opacity-30: hsl(0, 100%, 50%);
+  --color-blue-205-100-50: hsl(0, 100%, 50%);
+  --color-blue-205-100-95: hsl(0, 100%, 50%);
 
   --color-green-150-86-44: hsl(150, 86%, 44%);
 

--- a/lib/features/label-editing/LabelEditingPreview.js
+++ b/lib/features/label-editing/LabelEditingPreview.js
@@ -79,7 +79,8 @@ export default function LabelEditingPreview(eventBus, canvas, pathMap) {
     } else if (is(element, 'bpmn:Task') ||
                is(element, 'bpmn:CallActivity') ||
                is(element, 'bpmn:SubProcess') ||
-               is(element, 'bpmn:Participant')) {
+               is(element, 'bpmn:Participant') ||
+               is(element, 'bpmn:Lane')) {
       canvas.addMarker(element, MARKER_LABEL_HIDDEN);
     }
   });


### PR DESCRIPTION
## Beschreibung

1. Das bearbeiten eines Lane-Names funktioniert nun ohne das Texte überlappen

## Relevante Issues und/oder PRs

[Jira](https://5minds.atlassian.net/browse/PCE-1306)

## Wie lassen sich die Änderungen testen?

1. Studio starten und Prozess auswählen
2. Lane Name bearbeiten

## Checkliste

* [x] **Brief textual description** of the changes present
* [x] **Visual demo** attached
* [x] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
